### PR TITLE
Fix pyproject with BOM removal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-﻿[build-system]
+[build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
## Summary
- remove UTF-8 BOM from `pyproject.toml` so tools can read it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685986c2d05c8325a0a5b5c93aab1948