### PR TITLE
Add package metadata and init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,16 @@ build-backend = "setuptools.build_meta"
 name = "dtwproject"
 version = "0.1.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "Matt T", email = "matt@example.com" }
+]
+dependencies = [
+    "numpy",
+    "scipy",
+    "matplotlib",
+    "h5py",
+]
+
+[tool.setuptools]
+package-dir = { "dtwproject" = "src" }
+packages = ["dtwproject"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,7 @@
+"""DTW project package."""
+
+__all__ = [
+    "displayData",
+    "dtwAlgorithm",
+    "importData",
+]


### PR DESCRIPTION
## Summary
- add author and dependencies metadata in `pyproject.toml`
- specify setuptools configuration for the `dtwproject` package
- create `src/__init__.py` so modules form a package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_6878ec767a088325a3d181fc1c87061e