### PR TITLE
Add basic EDA notebooks

### DIFF
--- a/notebooks/EDA_full.ipynb
+++ b/notebooks/EDA_full.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c9892ebd",
+   "metadata": {},
+   "source": [
+    "# Combined EDA"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f373d59d",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates loading both global and local features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "381af309",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import scipy.io as sio\n",
+    "\n",
+    "project_root = Path().cwd().parent\n",
+    "sys.path.insert(0, str(project_root))\n",
+    "from src.displayData import inspect_mat_file\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac30b03a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g_path = project_root / 'tests' / 'testData' / 'GlobalFeatures' / 'u1001s0001_sg0001.mat'\n",
+    "l_path = project_root / 'tests' / 'testData' / 'LocalFunctions' / 'u1001s0001_sg0001.mat'\n",
+    "\n",
+    "g_feats = inspect_mat_file(g_path).get('globalFeatures')\n",
+    "l_feats = inspect_mat_file(l_path).get('localFunctions')\n",
+    "\n",
+    "if g_feats is not None and l_feats is not None:\n",
+    "    print('Global features shape:', g_feats.shape)\n",
+    "    print('Local functions shape:', l_feats.shape)\n",
+    "else:\n",
+    "    print('Missing data files')\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/EDA_global.ipynb
+++ b/notebooks/EDA_global.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f554d349",
+   "metadata": {},
+   "source": [
+    "# Global Features EDA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04f0e4d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import scipy.io as sio\n",
+    "\n",
+    "project_root = Path().cwd().parent\n",
+    "sys.path.insert(0, str(project_root))\n",
+    "from src.displayData import inspect_mat_file\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "426b226d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mat_path = project_root / 'tests' / 'testData' / 'GlobalFeatures' / 'u1001s0001_sg0001.mat'\n",
+    "features = inspect_mat_file(mat_path)\n",
+    "vec = features.get('globalFeatures')\n",
+    "if vec is not None:\n",
+    "    print('Vector length:', len(vec))\n",
+    "    print('Mean:', np.mean(vec))\n",
+    "    plt.figure()\n",
+    "    plt.plot(vec)\n",
+    "    plt.xlabel('Index')\n",
+    "    plt.ylabel('Value')\n",
+    "    plt.title('Global feature values')\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print('File not found or data missing')\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/EDA_local.ipynb
+++ b/notebooks/EDA_local.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8054f922",
+   "metadata": {},
+   "source": [
+    "# Local Functions EDA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5edb243f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import scipy.io as sio\n",
+    "\n",
+    "project_root = Path().cwd().parent\n",
+    "sys.path.insert(0, str(project_root))\n",
+    "from src.displayData import inspect_mat_file\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e0417a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mat_path = project_root / 'tests' / 'testData' / 'LocalFunctions' / 'u1001s0001_sg0001.mat'\n",
+    "features = inspect_mat_file(mat_path)\n",
+    "mat = features.get('localFunctions')\n",
+    "if mat is not None:\n",
+    "    print('Matrix shape:', mat.shape)\n",
+    "    plt.figure()\n",
+    "    plt.plot(mat[:,0], mat[:,1])\n",
+    "    plt.xlabel('X')\n",
+    "    plt.ylabel('Y')\n",
+    "    plt.title('First two coordinates')\n",
+    "    plt.show()\n",
+    "else:\n",
+    "    print('File not found or data missing')\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create minimal notebooks for global, local, and combined EDA
- notebooks load sample `.mat` files from `tests/testData` if available and print basic info

## Testing
- `PYTHONPATH=$(pwd) pytest -q` *(fails: File not found for test data)*

------
https://chatgpt.com/codex/tasks/task_e_687a553871008325bcf1389eb112594c