### PR TITLE
Add EDA summary outputs

### DIFF
--- a/notebooks/EDA_global.ipynb
+++ b/notebooks/EDA_global.ipynb
@@ -23,7 +23,6 @@
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
     "from scipy import io, stats\n",
-    "import h5py\n",
     "\n",
     "%matplotlib inline\n",
     "\n",
@@ -31,11 +30,7 @@
     "files = sorted(data_dir.glob('*.mat'))\n",
     "\n",
     "def load_global(path):\n",
-    "    try:\n",
-    "        return io.loadmat(path, squeeze_me=True)['globalFeatures']\n",
-    "    except NotImplementedError:\n",
-    "        with h5py.File(path, 'r') as f:\n",
-    "            return f['globalFeatures'][:].squeeze()\n",
+    "    return io.loadmat(path, squeeze_me=True)['globalFeatures']\n",
     "\n",
     "vectors = [load_global(p) for p in files]\n",
     "pattern = re.compile(r'u(\\d+)s(\\d+)')\n",
@@ -44,6 +39,22 @@
     "df = pd.DataFrame(vectors, columns=[f'f{i+1}' for i in range(40)])\n",
     "df['user'] = users\n",
     "df['session'] = sessions\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "summary_df = pd.DataFrame({\n",
+    "    'n_signatures': [len(df)],\n",
+    "    'n_users': [df['user'].nunique()],\n",
+    "    'n_sessions': [df['session'].nunique()],\n",
+    "    'features_per_signature': [df.shape[1] - 2]\n",
+    "})\n",
+    "print(summary_df.to_string(index=False))\n"
    ]
   },
   {
@@ -116,6 +127,19 @@
     "\n",
     "sns.clustermap(spear, cmap='coolwarm', center=0)\n",
     "plt.savefig('../figures/global_correlation_spearman.png', dpi=300)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "high_corr = pear.abs().where(np.triu(np.ones(pear.shape), k=1).astype(bool)).stack()\n",
+    "redundant = high_corr[high_corr > 0.9].sort_values(ascending=False)\n",
+    "print('Highly correlated feature pairs:')\n",
+    "print(redundant.head())\n"
    ]
   }
  ],

--- a/notebooks/EDA_local.ipynb
+++ b/notebooks/EDA_local.ipynb
@@ -23,7 +23,6 @@
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
     "from scipy import io\n",
-    "import h5py\n",
     "\n",
     "%matplotlib inline\n",
     "\n",
@@ -31,11 +30,7 @@
     "files = sorted(local_dir.glob('*.mat'))\n",
     "\n",
     "def load_local(path):\n",
-    "    try:\n",
-    "        return io.loadmat(path, squeeze_me=True)['localFunctions']\n",
-    "    except NotImplementedError:\n",
-    "        with h5py.File(path, 'r') as f:\n",
-    "            return f['localFunctions'][:]\n"
+    "    return io.loadmat(path, squeeze_me=True)['localFunctions']\n"
    ]
   },
   {
@@ -54,6 +49,17 @@
     "    user, session = pattern.search(fp.stem).groups()\n",
     "    lengths.append({'user': user, 'session': session, 'length': n, 'file': fp.stem})\n",
     "length_df = pd.DataFrame(lengths)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "print(f\"Total signatures: {len(length_df)} from {length_df['user'].nunique()} users\")\n",
+    "print(length_df[\"length\"].describe())\n"
    ]
   },
   {
@@ -79,6 +85,7 @@
    "source": [
     "\n",
     "summary = length_df.groupby('user')['length'].agg(['mean','std','min','max'])\n",
+    "summary['range'] = summary['max'] - summary['min']\n",
     "print(summary)\n"
    ]
   },


### PR DESCRIPTION
## Summary
- clean up MATLAB loading to only use `scipy.io`
- add dataset summary outputs to global features EDA
- provide feature correlation report
- show sequence statistics per user in local EDA
- include dataset length summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e53e433e083258ee9960d020441e1