### PR TITLE
Implement DTW cache builder

### DIFF
--- a/tests/test_compute_dtw.py
+++ b/tests/test_compute_dtw.py
@@ -1,0 +1,14 @@
+import numpy as np
+from src.dtw.compute_dtw import compute_pair_dtw
+
+
+def test_compute_pair_dtw_identity():
+    a = np.arange(5).reshape(-1, 1)
+    b = np.arange(5).reshape(-1, 1)
+    d_raw, n1, n2, n3, plen = compute_pair_dtw(a, b, backend="python")
+
+    assert d_raw == 0.0
+    assert plen == 5
+    assert n1 == 0.0
+    assert n2 == 0.0
+    assert n3 == 0.0


### PR DESCRIPTION
## Summary
- add new `compute_dtw` module to compute DTW distances and build cache
- expose dtw subpackage
- test DTW computation on simple sequences

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e898ea3988325bad741dde81df3e7