### PR TITLE
Add differentiable DTW layer with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 
 # Python bytecode
 __pycache__/
+# Runtime artifacts (generated locally, never committed)
+models/*.h5
+figures/*.png
+logs/**

--- a/models/diffdtw_baseline.py
+++ b/models/diffdtw_baseline.py
@@ -1,0 +1,17 @@
+from tensorflow.keras.layers import (Input, TimeDistributed, Dense,
+                                     GlobalAveragePooling1D)
+from tensorflow.keras.models import Model
+from src.keras_layers.diff_dtw import DiffDTW
+
+L, F = 128, 32
+ref_input = Input((L, F), name="reference")
+qry_input = Input((L, F), name="query")
+
+td = TimeDistributed(Dense(7, activation="relu"))
+ref_feat = GlobalAveragePooling1D()(td(ref_input))
+qry_feat = GlobalAveragePooling1D()(td(qry_input))
+
+dist = DiffDTW()([ref_feat, qry_feat])
+out = Dense(1, activation="sigmoid")(dist)
+
+model = Model([ref_input, qry_input], out, name="diffdtw_baseline")

--- a/notebooks/train_diffdtw.ipynb
+++ b/notebooks/train_diffdtw.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DiffDTW Training Stub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from tensorflow.keras.optimizers import Adam\n",
+    "from tensorflow.keras.losses import BinaryCrossentropy\n",
+    "from models.diffdtw_baseline import model\n",
+    "\n",
+    "# TODO: implement data generator\n",
+    "history = model.fit(..., epochs=1)\n",
+    "with open('results/diffdtw_history.json', 'w') as f:\n",
+    "    json.dump(history.history, f)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/keras_layers/diff_dtw.py
+++ b/src/keras_layers/diff_dtw.py
@@ -1,0 +1,71 @@
+import tensorflow as tf
+from tensorflow.keras.layers import Layer
+
+
+def _pairwise_distances(seq_a: tf.Tensor, seq_b: tf.Tensor) -> tf.Tensor:
+    """Compute squared Euclidean distances between sequence steps."""
+    a_exp = tf.expand_dims(seq_a, 2)  # (B, L_a, 1, F)
+    b_exp = tf.expand_dims(seq_b, 1)  # (B, 1, L_b, F)
+    return tf.reduce_sum(tf.square(a_exp - b_exp), axis=-1)  # (B, L_a, L_b)
+
+
+def _soft_dtw(seq_a: tf.Tensor, seq_b: tf.Tensor, gamma: float) -> tf.Tensor:
+    """Differentiable soft-DTW implementation for batches."""
+    D = _pairwise_distances(seq_a, seq_b)
+    B = tf.shape(D)[0]
+    N = tf.shape(D)[1]
+    M = tf.shape(D)[2]
+    dtype = D.dtype
+
+    inf = tf.constant(1e6, dtype=dtype)
+    R = tf.fill((B, N + 2, M + 2), inf)
+    idx0 = tf.stack(
+        [tf.range(B, dtype=tf.int32), tf.zeros((B,), tf.int32), tf.zeros((B,), tf.int32)],
+        axis=1,
+    )
+    R = tf.tensor_scatter_nd_update(R, idx0, tf.zeros((B,), dtype=dtype))
+
+    def body_i(i, R):
+        def body_j(j, R):
+            r0 = R[:, i, j]
+            r1 = R[:, i, j + 1]
+            r2 = R[:, i + 1, j]
+            r = tf.stack([r0, r1, r2], axis=-1)
+            softmin = -gamma * tf.reduce_logsumexp(-r / gamma, axis=-1)
+            val = D[:, i, j] + softmin
+            idx = tf.stack(
+                [tf.range(B, dtype=tf.int32), tf.fill([B], i + 1), tf.fill([B], j + 1)],
+                axis=1,
+            )
+            R = tf.tensor_scatter_nd_update(R, idx, val)
+            return j + 1, R
+
+        j0 = tf.constant(0)
+        _, R = tf.while_loop(lambda j, _: j < M, body_j, [j0, R])
+        return i + 1, R
+
+    i0 = tf.constant(0)
+    _, R = tf.while_loop(lambda i, _: i < N, body_i, [i0, R])
+    return R[:, N, M]
+
+
+class DiffDTW(Layer):
+    """Keras layer computing differentiable DTW distance."""
+
+    def __init__(self, gamma: float = 1.0, **kwargs):
+        super().__init__(**kwargs)
+        self.gamma = float(gamma)
+
+    def call(self, inputs):
+        seq_a, seq_b = inputs
+        dist = _soft_dtw(seq_a, seq_b, self.gamma)
+        return tf.expand_dims(dist, axis=-1)
+
+    def compute_output_shape(self, input_shape):
+        batch_size = input_shape[0][0]
+        return (batch_size, 1)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"gamma": self.gamma})
+        return config

--- a/tests/test_diff_dtw.py
+++ b/tests/test_diff_dtw.py
@@ -1,0 +1,37 @@
+import numpy as np
+import tensorflow as tf
+from src.keras_layers.diff_dtw import DiffDTW
+
+
+def soft_dtw_numpy(a, b, gamma=1.0):
+    """Reference soft-DTW implementation using NumPy."""
+    n, f = a.shape
+    m, _ = b.shape
+    D = np.sum((a[:, None, :] - b[None, :, :]) ** 2, axis=-1)
+    R = np.full((n + 1, m + 1), np.inf, dtype=np.float32)
+    R[0, 0] = 0.0
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            r = np.array([R[i - 1, j - 1], R[i - 1, j], R[i, j - 1]], dtype=np.float32)
+            softmin = -gamma * np.log(np.exp(-r[0] / gamma) + np.exp(-r[1] / gamma) + np.exp(-r[2] / gamma))
+            R[i, j] = D[i - 1, j - 1] + softmin
+    return R[n, m]
+
+
+def test_forward_distance():
+    a = np.array([[0.0], [1.0]], dtype=np.float32)
+    b = np.array([[1.0], [0.0]], dtype=np.float32)
+    layer = DiffDTW(gamma=1.0)
+    tf_dist = layer([a[None, ...], b[None, ...]])
+    np_dist = soft_dtw_numpy(a, b, gamma=1.0)
+    assert np.allclose(tf_dist.numpy().squeeze(), np_dist, atol=1e-5)
+
+
+def test_gradients():
+    seq_a = tf.random.uniform((2, 3, 2))
+    seq_b = tf.random.uniform((2, 3, 2))
+    layer = DiffDTW(gamma=1.0)
+    func = lambda x, y: layer([x, y])
+    (grad_a, grad_b), (num_a, num_b) = tf.test.compute_gradient(func, [seq_a, seq_b])
+    tf.debugging.assert_near(grad_a, num_a, rtol=1e-2, atol=1e-2)
+    tf.debugging.assert_near(grad_b, num_b, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
## Summary
- add `DiffDTW` layer implementing differentiable DTW
- create baseline contrastive model using the new layer
- add training stub notebook for future experimentation
- ignore training artifacts in `.gitignore`
- test forward calculation and gradients for `DiffDTW`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eacd6e47883258892f4c7b35da7d1