### PR TITLE
Unify catalog builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ signature verification workflow:
 1. **Data discovery & integrity check**
 
    ```bash
-   python -m data.loaders check-integrity
+   python -m data.catalog --config config.yaml
    ```
 
    Build `data/catalog.parquet` by scanning the `GlobalFeatures` and

--- a/src/data/catalog.py
+++ b/src/data/catalog.py
@@ -1,0 +1,74 @@
+"""Build a BiosecurID catalog of feature file paths."""
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+import yaml
+import pandas as pd
+
+from ..io.load_biosecurid import parse_filename
+
+
+def build_catalog(
+    *,
+    global_dir: Path | None = None,
+    local_dir: Path | None = None,
+    config: Path | None = None,
+    out_path: Path = Path("data/catalog.parquet"),
+) -> pd.DataFrame:
+    """Scan feature directories and write a catalog Parquet file."""
+    if config is not None:
+        with open(config, "r", encoding="utf-8") as fh:
+            cfg = yaml.safe_load(fh)
+        global_dir = Path(cfg["GlobalFeatures"]).expanduser()
+        local_dir = Path(cfg["LocalFunctions"]).expanduser()
+    if global_dir is None or local_dir is None:
+        raise ValueError("global_dir and local_dir must be provided")
+
+    records: list[dict] = []
+    missing: list[str] = []
+    for gfile in sorted(Path(global_dir).glob("u*.mat")):
+        try:
+            user, sess, samp = parse_filename(gfile.name)
+        except ValueError:
+            continue
+        lfile = Path(local_dir) / gfile.name
+        if not lfile.exists():
+            missing.append(gfile.name)
+            continue
+        records.append(
+            {
+                "user_id": user,
+                "session_id": sess,
+                "sample_id": samp,
+                "global_path": str(gfile.resolve()),
+                "local_path": str(lfile.resolve()),
+            }
+        )
+    df = pd.DataFrame.from_records(records)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(out_path)
+    if missing:
+        print(f"Warning: {len(missing)} local files missing")
+    print(f"\u2713 wrote catalog with {len(df)} entries \u2192 {out_path}")
+    return df
+
+
+def main() -> None:  # pragma: no cover - CLI helper
+    ap = argparse.ArgumentParser(description="Build BiosecurID catalog")
+    ap.add_argument("--config", type=Path, default=Path("config.yaml"))
+    ap.add_argument("--global-dir", type=Path)
+    ap.add_argument("--local-dir", type=Path)
+    ap.add_argument("--out", type=Path, default=Path("data/catalog.parquet"))
+    args = ap.parse_args()
+
+    build_catalog(
+        global_dir=args.global_dir,
+        local_dir=args.local_dir,
+        config=args.config if not args.global_dir and not args.local_dir else None,
+        out_path=args.out,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/data/loaders.py
+++ b/src/data/loaders.py
@@ -1,57 +1,30 @@
-"""Data discovery utilities for BiosecurID."""
+"""Legacy wrappers for building the BiosecurID catalog."""
 from __future__ import annotations
 
-import yaml
 from pathlib import Path
 import pandas as pd
 
-from ..io.load_biosecurid import parse_filename
+from .catalog import build_catalog
 
 
 def check_integrity(config_path: Path = Path("config.yaml")) -> pd.DataFrame:
-    """Parse feature directories and build a catalog."""
-    with open(config_path, "r", encoding="utf-8") as fh:
-        cfg = yaml.safe_load(fh)
-    gdir = Path(cfg["GlobalFeatures"]).expanduser()
-    ldir = Path(cfg["LocalFunctions"]).expanduser()
-
-    records = []
-    missing = []
-    for gfile in sorted(gdir.glob("u*.mat")):
-        try:
-            user, sess, samp = parse_filename(gfile.name)
-        except ValueError:
-            continue
-        lfile = ldir / gfile.name
-        if not lfile.exists():
-            missing.append(gfile.name)
-            continue
-        records.append(
-            {
-                "user_id": user,
-                "session_id": sess,
-                "sample_id": samp,
-                "global_path": str(gfile.resolve()),
-                "local_path": str(lfile.resolve()),
-            }
-        )
-    df = pd.DataFrame.from_records(records)
-    out_path = Path("data/catalog.parquet")
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    df.to_parquet(out_path)
-    if missing:
-        print(f"Warning: {len(missing)} local files missing")
-    print(f"✓ wrote catalog with {len(df)} entries → {out_path}")
-    return df
+    """Compatibility wrapper for the old CLI."""
+    return build_catalog(config=config_path)
 
 
 if __name__ == "__main__":  # pragma: no cover
     import argparse
 
-    ap = argparse.ArgumentParser(description="Check dataset integrity")
-    ap.add_argument("command", choices=["check-integrity"], nargs="?")
+    ap = argparse.ArgumentParser(description="Build BiosecurID catalog")
     ap.add_argument("--config", type=Path, default=Path("config.yaml"))
+    ap.add_argument("--global-dir", type=Path)
+    ap.add_argument("--local-dir", type=Path)
+    ap.add_argument("--out", type=Path, default=Path("data/catalog.parquet"))
     args = ap.parse_args()
 
-    if args.command == "check-integrity":
-        check_integrity(args.config)
+    build_catalog(
+        global_dir=args.global_dir,
+        local_dir=args.local_dir,
+        config=args.config if not args.global_dir and not args.local_dir else None,
+        out_path=args.out,
+    )

--- a/src/io/load_biosecurid.py
+++ b/src/io/load_biosecurid.py
@@ -5,7 +5,6 @@ Module to ingest all BiosecurID .mat files into a single analysis-ready catalog.
 """
 import re
 from pathlib import Path
-import pandas as pd
 import scipy.io as sio
 
 FILENAME_PATTERN = re.compile(r"u(?P<user>\d{4})s(?P<session>\d{4})_sg(?P<sample>\d{4})\.mat$")
@@ -44,44 +43,3 @@ def load_local(mat_path: Path):
     return mat['localFunctions']
 
 
-def build_catalog(
-    global_dir: Path,
-    local_dir: Path,
-    output_catalog: Path
-):
-    """
-    Scan both GlobalFeatures and LocalFunctions directories, parse metadata,
-    and build a master DataFrame with columns:
-      - user_id, session_id, sample_id
-      - global_path, local_path
-    Persists catalog to Parquet.
-    """
-    records = []
-
-    # assume both dirs contain same set of uXXXXsYYYY_sgZZZZ.mat files
-    for gfile in sorted(global_dir.glob('u*.mat')):
-        user, session, sample = parse_filename(gfile.name)
-        lfile = local_dir / gfile.name
-        if not lfile.exists():
-            continue  # or raise
-
-        records.append({
-            'user_id': user,
-            'session_id': session,
-            'sample_id': sample,
-            'global_path': str(gfile.resolve()),
-            'local_path': str(lfile.resolve()),
-        })
-
-    df = pd.DataFrame.from_records(records)
-    df.to_parquet(output_catalog)
-    return df
-
-
-if __name__ == '__main__':
-    project_root = Path(__file__).parents[2]
-    glob_dir = project_root / 'data' / 'processed' / 'GlobalFeatures'
-    loc_dir  = project_root / 'data' / 'raw' / 'LocalFunctions'
-    catalog  = project_root / 'data' / 'biosecurid_catalog.parquet'
-    df = build_catalog(glob_dir, loc_dir, catalog)
-    print(f"Catalog written with {len(df)} entries to {catalog}")


### PR DESCRIPTION
## Summary
- add `data.catalog.build_catalog` as single catalog builder
- refactor `data.loaders` to delegate to new builder
- remove old builder from `io.load_biosecurid`
- update README instructions

## Testing
- `pip install numpy pandas scipy pyarrow pytest matplotlib tensorflow-cpu`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dfaf461c8325a17d1b4fc363aae6